### PR TITLE
Add the possibility to use IP Group name in the rules

### DIFF
--- a/examples/deploy_fw_policy_with_ipgroups/main.tf
+++ b/examples/deploy_fw_policy_with_ipgroups/main.tf
@@ -149,7 +149,7 @@ module "rule_collection_group" {
 module "rule_collection_group_2" {
   source                                                   = "../../modules/rule_collection_groups"
   firewall_policy_rule_collection_group_firewall_policy_id = module.firewall_policy.resource.id
-  firewall_policy_rule_collection_group_name               = "IPGroupRCG"
+  firewall_policy_rule_collection_group_name               = "IPGroupRCG2"
   firewall_policy_rule_collection_group_priority           = 500
   ip_groups = {
     module.ip_groups.ip_groups.ipgroup1.name = module.ip_groups.ip_groups.ipgroup1.id

--- a/examples/deploy_fw_policy_with_ipgroups/main.tf
+++ b/examples/deploy_fw_policy_with_ipgroups/main.tf
@@ -145,3 +145,50 @@ module "rule_collection_group" {
     }
   ]
 }
+
+module "rule_collection_group_2" {
+  source                                                   = "../../modules/rule_collection_groups"
+  firewall_policy_rule_collection_group_firewall_policy_id = module.firewall_policy.resource.id
+  firewall_policy_rule_collection_group_name               = "IPGroupRCG"
+  firewall_policy_rule_collection_group_priority           = 500
+  ip_groups = {
+    module.ip_groups.ip_groups.ipgroup1.name = module.ip_groups.ip_groups.ipgroup1.id
+    module.ip_groups.ip_groups.ipgroup2.name = module.ip_groups.ip_groups.ipgroup2.id
+  }
+  firewall_policy_rule_collection_group_network_rule_collection = [
+    {
+      action   = "Allow"
+      name     = "NetworkRuleCollection2"
+      priority = 101
+      rule = [
+        {
+          name                  = "OutboundToIPGroups"
+          destination_ports     = ["443"]
+          destination_ip_groups = ["ipgroup1"]
+          source_ip_groups      = ["ipgroup2"]
+          protocols             = ["TCP"]
+        }
+      ]
+    }
+  ]
+  firewall_policy_rule_collection_group_application_rule_collection = [
+    {
+      action   = "Allow"
+      name     = "ApplicationRuleCollection"
+      priority = 201
+      rule = [
+        {
+          name              = "AllowMicrosoft"
+          destination_fqdns = ["*.microsoft.com"]
+          source_ip_groups  = ["ipgroup2"]
+          protocols = [
+            {
+              port = 443
+              type = "Https"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/.terraform-docs.yml
+++ b/modules/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.19.0"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/modules/rule_collection_groups/README.md
+++ b/modules/rule_collection_groups/README.md
@@ -21,6 +21,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
 
   dynamic "application_rule_collection" {
     for_each = var.firewall_policy_rule_collection_group_application_rule_collection == null ? [] : var.firewall_policy_rule_collection_group_application_rule_collection
+
     content {
       action   = application_rule_collection.value.action
       name     = application_rule_collection.value.name
@@ -28,6 +29,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
 
       dynamic "rule" {
         for_each = application_rule_collection.value.rule
+
         content {
           name                  = rule.value.name
           description           = rule.value.description
@@ -36,12 +38,13 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
           destination_fqdns     = rule.value.destination_fqdns
           destination_urls      = rule.value.destination_urls
           source_addresses      = rule.value.source_addresses
-          source_ip_groups      = rule.value.source_ip_groups
+          source_ip_groups      = lookup(var.ip_groups, rule.value.source_ip_groups, rule.value.source_ip_groups)
           terminate_tls         = rule.value.terminate_tls
           web_categories        = rule.value.web_categories
 
           dynamic "http_headers" {
             for_each = rule.value.http_headers == null ? [] : rule.value.http_headers
+
             content {
               name  = http_headers.value.name
               value = http_headers.value.value
@@ -49,6 +52,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
           }
           dynamic "protocols" {
             for_each = rule.value.protocols == null ? [] : rule.value.protocols
+
             content {
               port = protocols.value.port
               type = protocols.value.type
@@ -60,6 +64,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   }
   dynamic "nat_rule_collection" {
     for_each = var.firewall_policy_rule_collection_group_nat_rule_collection == null ? [] : var.firewall_policy_rule_collection_group_nat_rule_collection
+
     content {
       action   = nat_rule_collection.value.action
       name     = nat_rule_collection.value.name
@@ -67,6 +72,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
 
       dynamic "rule" {
         for_each = nat_rule_collection.value.rule
+
         content {
           name                = rule.value.name
           protocols           = rule.value.protocols
@@ -74,7 +80,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
           destination_address = rule.value.destination_address
           destination_ports   = rule.value.destination_ports
           source_addresses    = rule.value.source_addresses
-          source_ip_groups    = rule.value.source_ip_groups
+          source_ip_groups    = lookup(var.ip_groups, rule.value.source_ip_groups, rule.value.source_ip_groups)
           translated_address  = rule.value.translated_address
           translated_fqdn     = rule.value.translated_fqdn
         }
@@ -83,6 +89,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
   }
   dynamic "network_rule_collection" {
     for_each = var.firewall_policy_rule_collection_group_network_rule_collection == null ? [] : var.firewall_policy_rule_collection_group_network_rule_collection
+
     content {
       action   = network_rule_collection.value.action
       name     = network_rule_collection.value.name
@@ -90,21 +97,23 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
 
       dynamic "rule" {
         for_each = network_rule_collection.value.rule
+
         content {
           destination_ports     = rule.value.destination_ports
           name                  = rule.value.name
           protocols             = rule.value.protocols
           destination_addresses = rule.value.destination_addresses
           destination_fqdns     = rule.value.destination_fqdns
-          destination_ip_groups = rule.value.destination_ip_groups
+          destination_ip_groups = lookup(var.ip_groups, rule.value.destination_ip_groups, rule.value.destination_ip_groups)
           source_addresses      = rule.value.source_addresses
-          source_ip_groups      = rule.value.source_ip_groups
+          source_ip_groups      = lookup(var.ip_groups, rule.value.source_ip_groups, rule.value.source_ip_groups)
         }
       }
     }
   }
   dynamic "timeouts" {
     for_each = var.firewall_policy_rule_collection_group_timeouts == null ? [] : [var.firewall_policy_rule_collection_group_timeouts]
+
     content {
       create = timeouts.value.create
       delete = timeouts.value.delete
@@ -122,13 +131,13 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71, < 5.0.0)
 
 ## Providers
 
 The following providers are used by this module:
 
-- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 3.71)
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 3.71, < 5.0.0)
 
 ## Resources
 
@@ -178,7 +187,7 @@ Description: - `action` - (Required) The action to take for the application rule
 - `destination_urls` -
 - `name` - (Required) The name which should be used for this Firewall Policy Rule Collection Group. Changing this forces a new Firewall Policy Rule Collection Group to be created.
 - `source_addresses` -
-- `source_ip_groups` -
+- `source_ip_groups` - (Optional) The ID or name of the source IP groups. If a name is used, it must be defined in `var.ip_groups` to map to its corresponding resource ID.
 - `terminate_tls` -
 - `web_categories` -
 
@@ -238,7 +247,7 @@ Description: - `action` - (Required) The action to take for the NAT rules in thi
 - `name` - (Required) The name which should be used for this Firewall Policy Rule Collection Group. Changing this forces a new Firewall Policy Rule Collection Group to be created.
 - `protocols` -
 - `source_addresses` -
-- `source_ip_groups` -
+- `source_ip_groups` - (Optional) The ID or name of the source IP groups. If a name is used, it must be defined in `var.ip_groups` to map to its corresponding resource ID.
 - `translated_address` -
 - `translated_fqdn` -
 - `translated_port` -
@@ -278,12 +287,12 @@ Description: - `action` - (Required) The action to take for the network rules in
 - `description` -
 - `destination_addresses` -
 - `destination_fqdns` -
-- `destination_ip_groups` -
+- `destination_ip_groups` - (Optional) The ID or name of the destination IP groups. If a name is used, it must be defined in `var.ip_groups` to map to its corresponding resource ID.
 - `destination_ports` -
 - `name` - (Required) The name which should be used for this Firewall Policy Rule Collection Group. Changing this forces a new Firewall Policy Rule Collection Group to be created.
 - `protocols` -
 - `source_addresses` -
-- `source_ip_groups` -
+- `source_ip_groups` - (Optional) The ID or name of the source IP groups. If a name is used, it must be defined in `var.ip_groups` to map to its corresponding resource ID.
 
 Type:
 
@@ -327,6 +336,27 @@ object({
 ```
 
 Default: `null`
+
+### <a name="input_ip_groups"></a> [ip\_groups](#input\_ip\_groups)
+
+Description: (Optional) A map of IP Group names to their corresponding resource IDs. This variable allows you to reference IP Groups by name in the firewall rules for easier management.
+
+- Key: The name of the IP Group (as used in the firewall rules).
+- Value: The resource ID of the IP Group.  
+
+If you provide the name of an IP Group in the firewall rules, it must be defined in `var.ip_groups` to map it to its resource ID. If you provide the resource ID directly in the rules, no mapping is required.
+
+Example:
+```
+{
+  "ip-group-1-name" = "ip-group-1-resource-id",
+  "ip-group-2-name" = "ip-group-2-resource-id"
+}
+```
+
+Type: `map(string)`
+
+Default: `{}`
 
 ## Outputs
 

--- a/modules/rule_collection_groups/main.tf
+++ b/modules/rule_collection_groups/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
           destination_fqdns     = rule.value.destination_fqdns
           destination_urls      = rule.value.destination_urls
           source_addresses      = rule.value.source_addresses
-          source_ip_groups      = rule.value.source_ip_groups
+          source_ip_groups      = lookup(var.ip_groups, rule.value.source_ip_groups, rule.value.source_ip_groups)
           terminate_tls         = rule.value.terminate_tls
           web_categories        = rule.value.web_categories
 
@@ -64,7 +64,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
           destination_address = rule.value.destination_address
           destination_ports   = rule.value.destination_ports
           source_addresses    = rule.value.source_addresses
-          source_ip_groups    = rule.value.source_ip_groups
+          source_ip_groups    = lookup(var.ip_groups, rule.value.source_ip_groups, rule.value.source_ip_groups)
           translated_address  = rule.value.translated_address
           translated_fqdn     = rule.value.translated_fqdn
         }
@@ -88,9 +88,9 @@ resource "azurerm_firewall_policy_rule_collection_group" "this" {
           protocols             = rule.value.protocols
           destination_addresses = rule.value.destination_addresses
           destination_fqdns     = rule.value.destination_fqdns
-          destination_ip_groups = rule.value.destination_ip_groups
+          destination_ip_groups = lookup(var.ip_groups, rule.value.destination_ip_groups, rule.value.destination_ip_groups)
           source_addresses      = rule.value.source_addresses
-          source_ip_groups      = rule.value.source_ip_groups
+          source_ip_groups      = lookup(var.ip_groups, rule.value.source_ip_groups, rule.value.source_ip_groups)
         }
       }
     }

--- a/modules/rule_collection_groups/variables.tf
+++ b/modules/rule_collection_groups/variables.tf
@@ -56,8 +56,8 @@ variable "firewall_policy_rule_collection_group_application_rule_collection" {
  - `destination_fqdns` - 
  - `destination_urls` - 
  - `name` - (Required) The name which should be used for this Firewall Policy Rule Collection Group. Changing this forces a new Firewall Policy Rule Collection Group to be created.
- - `source_addresses` - 
- - `source_ip_groups` - 
+ - `source_addresses` -
+ - `source_ip_groups` - (Optional) The ID or name of the source IP groups. If a name is used, it must be defined in `var.ip_groups` to map to its corresponding resource ID.
  - `terminate_tls` - 
  - `web_categories` - 
 
@@ -105,7 +105,7 @@ variable "firewall_policy_rule_collection_group_nat_rule_collection" {
  - `name` - (Required) The name which should be used for this Firewall Policy Rule Collection Group. Changing this forces a new Firewall Policy Rule Collection Group to be created.
  - `protocols` - 
  - `source_addresses` - 
- - `source_ip_groups` - 
+ - `source_ip_groups` - (Optional) The ID or name of the source IP groups. If a name is used, it must be defined in `var.ip_groups` to map to its corresponding resource ID.
  - `translated_address` - 
  - `translated_fqdn` - 
  - `translated_port` - 
@@ -140,12 +140,12 @@ variable "firewall_policy_rule_collection_group_network_rule_collection" {
  - `description` - 
  - `destination_addresses` - 
  - `destination_fqdns` - 
- - `destination_ip_groups` - 
+ - `destination_ip_groups` - (Optional) The ID or name of the destination IP groups. If a name is used, it must be defined in `var.ip_groups` to map to its corresponding resource ID.
  - `destination_ports` - 
  - `name` - (Required) The name which should be used for this Firewall Policy Rule Collection Group. Changing this forces a new Firewall Policy Rule Collection Group to be created.
  - `protocols` - 
  - `source_addresses` - 
- - `source_ip_groups` - 
+ - `source_ip_groups` - (Optional) The ID or name of the source IP groups. If a name is used, it must be defined in `var.ip_groups` to map to its corresponding resource ID.
 EOT
 }
 
@@ -163,4 +163,14 @@ variable "firewall_policy_rule_collection_group_timeouts" {
  - `read` - (Defaults to 5 minutes) Used when retrieving the Firewall Policy Rule Collection Group.
  - `update` - (Defaults to 30 minutes) Used when updating the Firewall Policy Rule Collection Group.
 EOT
+}
+
+variable "ip_groups" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  (Optional) The ID or name of the source IP groups to be used in the rule. 
+  - If you provide the name of an IP group in the rules, it must be defined in `var.ip_groups` for mapping to its corresponding resource ID.
+  - If you provide the resource ID directly in the rules, no mapping is required.
+  EOT
 }

--- a/modules/rule_collection_groups/variables.tf
+++ b/modules/rule_collection_groups/variables.tf
@@ -169,8 +169,17 @@ variable "ip_groups" {
   type        = map(string)
   default     = {}
   description = <<-EOT
-  (Optional) The ID or name of the source IP groups to be used in the rule. 
-  - If you provide the name of an IP group in the rules, it must be defined in `var.ip_groups` for mapping to its corresponding resource ID.
-  - If you provide the resource ID directly in the rules, no mapping is required.
+  (Optional) A map of IP Group names to their corresponding resource IDs. This variable allows you to reference IP Groups by name in the firewall rules for easier management.
+  
+  - Key: The name of the IP Group (as used in the firewall rules).
+  - Value: The resource ID of the IP Group.
+  
+  If you provide the name of an IP Group in the firewall rules, it must be defined in `var.ip_groups` to map it to its resource ID. If you provide the resource ID directly in the rules, no mapping is required.
+
+  Example:
+  {
+    "ip-group-name-1" = "ip-group-1-resource-id",
+    "ip-group-name-2" = "ip-group-2-resource-id"
+  }
   EOT
 }

--- a/modules/rule_collection_groups/variables.tf
+++ b/modules/rule_collection_groups/variables.tf
@@ -177,9 +177,11 @@ variable "ip_groups" {
   If you provide the name of an IP Group in the firewall rules, it must be defined in `var.ip_groups` to map it to its resource ID. If you provide the resource ID directly in the rules, no mapping is required.
 
   Example:
+  ```
   {
-    "ip-group-name-1" = "ip-group-1-resource-id",
-    "ip-group-name-2" = "ip-group-2-resource-id"
+    "ip-group-1-name" = "ip-group-1-resource-id",
+    "ip-group-2-name" = "ip-group-2-resource-id"
   }
+  ```
   EOT
 }


### PR DESCRIPTION
## Description

This update introduces the ability to use IP Group names within firewall rules, allowing for more readable and maintainable Terraform HCL configurations. By referencing IP Group names, rather than resource IDs, managing large-scale firewall policies becomes simpler and more intuitive, especially in environments with many IP Groups. This feature enhances the readability and reduces the complexity of maintaining extensive firewall configurations in Terraform.

-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
